### PR TITLE
Update Kontrol test name, Makefile; format lemmas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ aderyn :; aderyn --root .
 certora :; certoraRun ./test/invariant-break/formal-verification/certora/FVCatches.conf
 
 kontrol-build :;  kontrol build --rekompile --require lemmas.k --module-import KontrolTest:FV-LEMMAS
-kontrol-prove :;  kontrol prove --match-test KontrolTest.check_hellFunc_doesnt_revert_kontrol --fail-fast --use-booster --counterexample-information --auto-abstract-gas
-kontrol-view :; kontrol view-kcfg KontrolTest.check_hellFunc_doesnt_revert_kontrol
-kontrol-node :; kontrol get-model KontrolTest.check_hellFunc_doesnt_revert_kontrol --node 162 --use-booster
+kontrol-prove :;  kontrol prove --match-test KontrolTest.test_hellFunc_doesnt_revert_kontrol --fail-fast --counterexample-information --auto-abstract-gas --no-break-on-calls
+kontrol-view :; kontrol view-kcfg KontrolTest.test_hellFunc_doesnt_revert_kontrol
+kontrol-node :; kontrol get-model KontrolTest.test_hellFunc_doesnt_revert_kontrol --node 86
 
 halmos :; halmos --function check_hellFunc_doesnt_revert_halmos

--- a/lemmas.k
+++ b/lemmas.k
@@ -54,7 +54,7 @@ module FV-LEMMAS
     rule { true  #Equals X:Int ==Int Y:Int } => { X #Equals Y } [simplification]
     rule { false #Equals X     ==K   Y     } => #Not ( { X #Equals Y } ) [simplification]
     rule { false #Equals X:Int ==Int Y:Int } => #Not ( { X #Equals Y } ) [simplification]
-    // rule { true  #Equals notBool X:Bool } => { false #Equals X } [simplification]
+    rule { true  #Equals notBool X:Bool } => { false #Equals X } [simplification]
     rule { false #Equals notBool X:Bool } => { true  #Equals X } [simplification]
 
     rule { X     ==K   Y     #Equals true  } => { X #Equals Y } [simplification]
@@ -261,8 +261,8 @@ module FV-LEMMAS
     rule { false #Equals _ in .Set} => #Top    [simplification]
 
     rule S:Set |Set SetItem( X ) => S requires X in S [simplification]
-    // rule X in _:Set SetItem( Y ) => true   requires X ==Int Y  [simplification]
-    // rule X in S:Set SetItem( Y ) => X in S requires X =/=Int Y [simplification]
+    rule X in _:Set SetItem( Y ) => true   requires X ==Int Y  [simplification]
+    rule X in S:Set SetItem( Y ) => X in S requires X =/=Int Y [simplification]
     rule (S1:Set |Set SetItem( X )) |Set S2:Set => S1 |Set S2                requires         X in S2 [simplification, concrete(X, S2)]
     rule (S1:Set |Set SetItem( X )) |Set S2:Set => S1 |Set ( SetItem(X) S2 ) requires notBool X in S2 [simplification, concrete(X, S2)]
     //
@@ -298,11 +298,6 @@ module FV-LEMMAS
 
     rule [keccak-eq-conc-false-ml]: { keccak(_A) #Equals _B } => #Bottom [symbolic(_A), concrete(_B), simplification, comm]
 
-    // // WARNING: Extremely unsound: corollary of `keccak-eq-conc-false`
-    // rule [keccak-eq-conc-false-extended]:
-    //   ( ( keccak ( X ) +Int A ) modInt pow256 ) ==Int Y => false
-    //   requires 0 <Int A andBool A <Int pow256
-    //   [simplification, symbolic(X), concrete(A, Y)]
     // keccak is injective
     rule [keccak-inj]: keccak(A) ==Int keccak(B) => A ==K B [simplification]
 
@@ -318,7 +313,8 @@ module FV-LEMMAS
     rule { X #Equals keccak (_) } => #Bottom
       requires X <Int 0 orBool X >=Int pow256
       [concrete(X), simplification]
-    // lemma that says that anything negative is smaller than a keccak
+  
+    // anything negative is smaller than a keccak
     rule X <Int keccak ( _ ) => true
       requires X <Int 0
       [concrete(X), simplification]

--- a/test/invariant-break/formal-verification/KontrolTest.t.sol
+++ b/test/invariant-break/formal-verification/KontrolTest.t.sol
@@ -13,9 +13,11 @@ contract KontrolTest is StdInvariant, Test, KontrolCheats {
         fvc = new FormalVerificationCatches();
     }
 
-    function check_hellFunc_doesnt_revert_kontrol(uint128 num) public {
+    function test_hellFunc_doesnt_revert_kontrol(uint128 num) public {
+        // invoke Kontrol cheatcode
+        // kevm.infiniteGas();
+
         // perform low level call
-        kevm.infiniteGas();
         (bool success,) = address(fvc).staticcall(abi.encodeWithSelector(fvc.hellFunc.selector, num));
         assert(success);
     }


### PR DESCRIPTION
This PR updates Kontrol-related tests, lemmas, and instructions in Makefile. In particular, it
- renames `check_hellFunc_doesnt_revert_kontrol` to `test_hellFunc_doesnt_revert_kontrol` in `KontrolTest`, which is needed for the test to be reported as failing once a reverting path is identified (in Kontrol, functions that are _not_ prefixed with `test` are explored but not checked for failures to report);
- updates the test name in `Makefile` instructions accordingly;
- comments the cheatcode invocation `kevm.infiniteGas()` in `KontrolTest` — infinite gas is now being assumed by default in Kontrol (in our documentation it is just meant to serve as an example of Kontrol-specific cheatcodes);
- removes `--use-booster` flag from instructions in `Makefile`, since it is now on [by default](https://github.com/runtimeverification/kontrol/pull/75);
- adds `--no-break-on-calls` flag to `kontrol prove` command in `Makefile` — this option instructs Kontrol to _not_ save a KCFG node every time a `CALL` is made, which speeds up the execution;
- changes a failing node number in `get-model` command according to the results of the updated `kontrol prove` instruction;
- performs a minor cleanup of `lemmas.k` 

Please also note that we [fixed](https://github.com/runtimeverification/kontrol/pull/244) an issue with model generation, so  `kontrol prove --counterexample-information` will now return a model as follows:
```
PROOF FAILED: KontrolTest.test_hellFunc_doesnt_revert_kontrol(uint128):0
1 Failure nodes. (0 pending and 1 failing)
...
  Model:
    VV0_num_114b9705 = 99
```

Running `kontrol get-model` for the same failing node will return the same result.