### PR TITLE
docs: fix wrong internal linking in `README.md` for `invariant-break`

### DIFF
--- a/src/invariant-break/README.md
+++ b/src/invariant-break/README.md
@@ -301,7 +301,7 @@ It's different from a fuzzer, as a fuzzer tries inputs for `y`. Whereas a SAT So
 
 ### Code Example
 
-You can view [../../test/invariant-break/FormalVerificationCatchesTest.t.sol](../../test/invariant-break/FormalVerificationCatchesTest.t.sol) for a full example. 
+You can view [../../test/invariant-break/formal-verification/HalmosTest.t.sol](../../test/invariant-break/formal-verification/HalmosTest.t.sol) for a full example. 
 
 ### Pros & Cons
 


### PR DESCRIPTION
`FormalVerificationCatchesTest.t.sol` was renamed to `HalmosTest.t.sol`.

Refs: e597d29