### PR TITLE
Fixed overflow bug in StatefulFuzzCatches

### DIFF
--- a/src/invariant-break/StatefulFuzzCatches.sol
+++ b/src/invariant-break/StatefulFuzzCatches.sol
@@ -3,19 +3,19 @@ pragma solidity 0.8.20;
 
 // INVARIANT: doMoreMathAgain should never return 0
 contract StatefulFuzzCatches {
-    uint256 public myValue = 1;
+    uint128 public myValue = 1;
     uint256 public storedValue = 100;
 
     /*
      * @dev Should never return 0
      */
     function doMoreMathAgain(uint128 myNumber) public returns (uint256) {
-        uint256 response = (uint256(myNumber) / 1) + myValue;
+        uint256 response = uint256(myNumber) + uint256(myValue);
         storedValue = response;
         return response;
     }
 
-    function changeValue(uint256 newValue) public {
+    function changeValue(uint128 newValue) public {
         myValue = newValue;
     }
 }


### PR DESCRIPTION
Updated variables to be uint128 instead to ensure no overflow error during invariant fuzzing