### PR TITLE
fix: remove `--no-commit` flag from forge command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit && forge install runtimeverification/kontrol-cheatcodes --no-commit
+install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts && forge install runtimeverification/kontrol-cheatcodes
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
### Description
When using `forge Version: 1.2.3-stable` and trying to run `make` in the current repository, the following error is returned:
```
forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit && forge install runtimeverification/kontrol-cheatcodes --no-commit

error: unexpected argument '--no-commit' found

  tip: a similar argument exists: '--commit'
```

### Root Cause
- Foundry PR [#9884](https://github.com/foundry-rs/foundry/pull/9884) removed the `--no-commit` flag making `--no-commit` the default behavior.
- This change was included in foundry's [rc-1](https://github.com/foundry-rs/foundry/releases/tag/rc-1) release.

### Suggested Change
Remove the  `--no-commit` flag from the [forge](https://github.com/Cyfrin/sc-exploits-minimized/blob/c86fea2a90b6ad0becc2f5ad8b4a8ecda55f95b5/Makefile#L15) command in the Makefile.
